### PR TITLE
Decouple `CompletionManager` and `ModificationManager`

### DIFF
--- a/components/CompletionManager.cc
+++ b/components/CompletionManager.cc
@@ -23,7 +23,7 @@ using namespace utils;
 
 namespace {
     constexpr auto completionGeneratedKey = "CMWCODER_completionGenerated";
-    const vector<string> keywords = {"if", "for", "switch", "while"};
+    const vector<string> keywords = {"class", "if", "for", "struct", "switch", "union", "while"};
 }
 
 CompletionManager::CompletionManager() {

--- a/components/CompletionManager.cc
+++ b/components/CompletionManager.cc
@@ -35,15 +35,12 @@ void CompletionManager::interactionAcceptCompletion(const any&) {
     _isJustAccepted.store(true);
     if (const auto [oldCompletion, cacheOffset] = _completionCache.reset();
         !oldCompletion.content().empty()) {
-        {
-            shared_lock lock(_componentsMutex);
-            system::setEnvironmentVariable(
-                completionGeneratedKey,
-                (oldCompletion.isSnippet() ? "1" : "0") +
-                InteractionMonitor::GetInstance()->getLineContent() +
-                oldCompletion.content().substr(cacheOffset)
-            );
-        }
+        system::setEnvironmentVariable(
+            completionGeneratedKey,
+            (oldCompletion.isSnippet() ? "1" : "0") +
+            InteractionMonitor::GetInstance()->getLineContent() +
+            oldCompletion.content().substr(cacheOffset)
+        );
         WindowManager::GetInstance()->sendAcceptCompletion();
         WebsocketManager::GetInstance()->sendAction(WsAction::CompletionAccept);
         logger::log(format("Accepted completion: {}", oldCompletion.stringify()));

--- a/components/CompletionManager.cc
+++ b/components/CompletionManager.cc
@@ -23,6 +23,7 @@ using namespace utils;
 
 namespace {
     constexpr auto completionGeneratedKey = "CMWCODER_completionGenerated";
+    const vector<string> keywords = {"if", "for", "switch", "while"};
 }
 
 CompletionManager::CompletionManager() {
@@ -146,43 +147,57 @@ void CompletionManager::interactionNavigate(const any& data) {
 
 void CompletionManager::interactionNormalInput(const any& data) {
     try {
+        bool needRetrieveCompletion = false;
         const auto character = any_cast<char>(data);
         // _isContinuousEnter.store(false);
         _isJustAccepted.store(false);
         if (const auto nextCacheOpt = _completionCache.next();
             nextCacheOpt.has_value()) {
             // Has valid cache
-            const auto [currentChar, completionOpt] = nextCacheOpt.value();
-            try {
-                if (character == currentChar) {
-                    // Cache hit
-                    if (completionOpt.has_value()) {
-                        // In cache
-                        WebsocketManager::GetInstance()->sendAction(WsAction::CompletionCache, false);
-                        logger::log("Normal input. Send CompletionCache due to cache hit");
-                    } else {
-                        // Out of cache
-                        _completionCache.reset();
-                        WebsocketManager::GetInstance()->sendAction(WsAction::CompletionAccept);
-                        logger::log("Normal input. Send CompletionAccept due to cache complete");
-                    }
+            if (const auto [currentChar, completionOpt] = nextCacheOpt.value();
+                character == currentChar) {
+                // Cache hit
+                if (completionOpt.has_value()) {
+                    // In cache
+                    WebsocketManager::GetInstance()->sendAction(WsAction::CompletionCache, false);
+                    logger::log("Normal input. Send CompletionCache due to cache hit");
                 } else {
-                    // Cache miss
-                    _cancelCompletion();
-                    logger::log("Normal input. Send CompletionCancel due to cache miss");
-                    _debounceRetrieveCompletionTime.store(chrono::high_resolution_clock::now());
-                    _needRetrieveCompletion.store(true);
+                    // Out of cache
+                    _completionCache.reset();
+                    WebsocketManager::GetInstance()->sendAction(WsAction::CompletionAccept);
+                    logger::log("Normal input. Send CompletionAccept due to cache complete");
                 }
-            } catch (runtime_error& e) {
-                logger::warn(e.what());
+            } else {
+                // Cache miss
+                _cancelCompletion();
+                logger::log("Normal input. Send CompletionCancel due to cache miss");
+                needRetrieveCompletion = true;
             }
         } else {
             // No valid cache
+            needRetrieveCompletion = true;
+        }
+        if (needRetrieveCompletion && character != '}') {
+            const auto interactionMonitor = InteractionMonitor::GetInstance();
+            const auto currentCaretPosition = interactionMonitor->getCaretPosition();
+            if (const auto currentLineContent = interactionMonitor->getLineContent(currentCaretPosition.line);
+                currentCaretPosition.character == currentLineContent.size() - 1) {
+                if (character == ';' &&
+                    ranges::none_of(keywords, [&currentLineContent](const string& keyword) {
+                        return regex_match(currentLineContent, regex(format(R"(\b{}\b)", keyword)));
+                    })) {
+                    logger::info("Normal input. Ignore due to ';' without any keyword");
+                    return;
+                }
+            }
+
             _debounceRetrieveCompletionTime.store(chrono::high_resolution_clock::now());
             _needRetrieveCompletion.store(true);
         }
     } catch (const bad_any_cast& e) {
         logger::warn(format("Invalid interactionNormalInput data: {}", e.what()));
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
     }
 }
 
@@ -271,31 +286,35 @@ void CompletionManager::_cancelCompletion() {
 }
 
 void CompletionManager::_sendCompletionGenerate() {
-    shared_lock componentsLock(_componentsMutex);
-    shared_lock editorInfoLock(_editorInfoMutex);
-    const auto [xPixel, yPixel] = InteractionMonitor::GetInstance()->getCaretPixels(
-        _components.caretPosition.line
-    );
-    _wsActionSentTime.store(chrono::high_resolution_clock::now());
-    WebsocketManager::GetInstance()->sendAction(
-        WsAction::CompletionGenerate,
-        {
+    try {
+        shared_lock componentsLock(_componentsMutex);
+        shared_lock editorInfoLock(_editorInfoMutex);
+        const auto [xPixel, yPixel] = InteractionMonitor::GetInstance()->getCaretPixels(
+            _components.caretPosition.line
+        );
+        _wsActionSentTime.store(chrono::high_resolution_clock::now());
+        WebsocketManager::GetInstance()->sendAction(
+            WsAction::CompletionGenerate,
             {
-                "caret", {
-                    {"character", _components.caretPosition.character},
-                    {"line", _components.caretPosition.line},
-                    {"xPixel", xPixel},
-                    {"yPixel", yPixel},
-                }
-            },
-            {"path", encode(_components.path, crypto::Encoding::Base64)},
-            {"prefix", encode(_components.prefix, crypto::Encoding::Base64)},
-            {"projectId", _editorInfo.projectId},
-            {"suffix", encode(_components.suffix, crypto::Encoding::Base64)},
-            {"symbolString", encode(_components.symbolString, crypto::Encoding::Base64)},
-            {"tabString", encode(_components.tabString, crypto::Encoding::Base64)},
-        }
-    );
+                {
+                    "caret", {
+                        {"character", _components.caretPosition.character},
+                        {"line", _components.caretPosition.line},
+                        {"xPixel", xPixel},
+                        {"yPixel", yPixel},
+                    }
+                },
+                {"path", encode(_components.path, crypto::Encoding::Base64)},
+                {"prefix", encode(_components.prefix, crypto::Encoding::Base64)},
+                {"projectId", _editorInfo.projectId},
+                {"suffix", encode(_components.suffix, crypto::Encoding::Base64)},
+                {"symbolString", encode(_components.symbolString, crypto::Encoding::Base64)},
+                {"tabString", encode(_components.tabString, crypto::Encoding::Base64)},
+            }
+        );
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
+    }
 }
 
 void CompletionManager::_threadDebounceRetrieveCompletion() {
@@ -304,49 +323,54 @@ void CompletionManager::_threadDebounceRetrieveCompletion() {
             if (_needRetrieveCompletion.load()) {
                 if (const auto pastTime = chrono::high_resolution_clock::now() - _debounceRetrieveCompletionTime.load();
                     pastTime >= chrono::milliseconds(500)) {
-                    const auto currentCaretPosition = InteractionMonitor::GetInstance()->getCaretPosition();
-                    const auto getContextLine = [&](const int offset = 0) {
-                        return InteractionMonitor::GetInstance()->
-                                getLineContent(currentCaretPosition.line + offset);
-                    };
-                    if (_isNewLine) {
-                        auto prefix = getContextLine().substr(0, currentCaretPosition.character);
-                        auto suffix = getContextLine().substr(currentCaretPosition.character);
-                        for (auto index = 1; index <= 30; ++index) {
-                            prefix.insert(0, getContextLine(-index)).insert(0, "\r\n");
-                        }
-                        for (auto index = 1; index <= 5; ++index) {
-                            suffix.append("\r\n").append(getContextLine(index));
-                        } {
+                    try {
+                        const auto currentCaretPosition = InteractionMonitor::GetInstance()->getCaretPosition();
+                        const auto getContextLine = [&](const int offset = 0) {
+                            return InteractionMonitor::GetInstance()->
+                                    getLineContent(currentCaretPosition.line + offset);
+                        };
+                        if (_isNewLine) {
+                            auto prefix = getContextLine().substr(0, currentCaretPosition.character);
+                            auto suffix = getContextLine().substr(currentCaretPosition.character);
+                            for (auto index = 1; index <= 30; ++index) {
+                                prefix.insert(0, getContextLine(-index)).insert(0, "\r\n");
+                            }
+                            for (auto index = 1; index <= 5; ++index) {
+                                suffix.append("\r\n").append(getContextLine(index));
+                            } {
+                                unique_lock lock(_componentsMutex);
+                                _components.caretPosition = currentCaretPosition;
+                                _components.path = InteractionMonitor::GetInstance()->getFileName();
+                                _components.prefix = move(prefix);
+                                _components.suffix = move(suffix);
+                            }
+
+                            _isNewLine = false;
+                        } else {
+                            auto prefix = getContextLine().substr(0, currentCaretPosition.character);
+                            auto suffix = getContextLine().substr(currentCaretPosition.character);
                             unique_lock lock(_componentsMutex);
                             _components.caretPosition = currentCaretPosition;
                             _components.path = InteractionMonitor::GetInstance()->getFileName();
-                            _components.prefix = move(prefix);
-                            _components.suffix = move(suffix);
+                            if (const auto lastNewLineIndex = _components.prefix.find_last_of('\n');
+                                lastNewLineIndex != string::npos) {
+                                _components.prefix = _components.prefix.substr(0, lastNewLineIndex).append(prefix);
+                            } else {
+                                _components.prefix = prefix;
+                            }
+                            if (const auto firstNewLineIndex = suffix.find_first_of('\n');
+                                firstNewLineIndex != string::npos) {
+                                _components.suffix = _components.suffix.substr(firstNewLineIndex + 1).insert(0, suffix);
+                            } else {
+                                _components.suffix = suffix;
+                            }
                         }
-
-                        _isNewLine = false;
-                    } else {
-                        auto prefix = getContextLine().substr(0, currentCaretPosition.character);
-                        auto suffix = getContextLine().substr(currentCaretPosition.character);
-                        unique_lock lock(_componentsMutex);
-                        _components.caretPosition = currentCaretPosition;
-                        _components.path = InteractionMonitor::GetInstance()->getFileName();
-                        if (const auto lastNewLineIndex = _components.prefix.find_last_of('\n');
-                            lastNewLineIndex != string::npos) {
-                            _components.prefix = _components.prefix.substr(0, lastNewLineIndex).append(prefix);
-                        } else {
-                            _components.prefix = prefix;
-                        }
-                        if (const auto firstNewLineIndex = suffix.find_first_of('\n');
-                            firstNewLineIndex != string::npos) {
-                            _components.suffix = _components.suffix.substr(firstNewLineIndex + 1).insert(0, suffix);
-                        } else {
-                            _components.suffix = suffix;
-                        }
+                        _sendCompletionGenerate();
+                        _needRetrieveCompletion.store(false);
+                    } catch (const runtime_error& e) {
+                        logger::warn(e.what());
+                        this_thread::sleep_for(chrono::milliseconds(10));
                     }
-                    _sendCompletionGenerate();
-                    _needRetrieveCompletion.store(false);
                 }
             } else {
                 this_thread::sleep_for(chrono::milliseconds(10));

--- a/components/CompletionManager.h
+++ b/components/CompletionManager.h
@@ -26,7 +26,7 @@ namespace components {
             std::string version;
         };
 
-        CompletionManager() = default;
+        CompletionManager();
 
         void interactionAcceptCompletion(const std::any&);
 
@@ -48,10 +48,6 @@ namespace components {
 
         // TODO: Remove old methods
 
-        void retrieveWithCurrentPrefix(const std::string& currentPrefix);
-
-        void retrieveWithFullInfo(Components&& components);
-
         void setAutoCompletion(bool isAutoCompletion);
 
         void setProjectId(const std::string& projectId);
@@ -64,16 +60,15 @@ namespace components {
         EditorInfo _editorInfo;
 
         // TODO: Check if _isJustAccepted is still needed
-        std::atomic<bool> _isAutoCompletion{true}, _isContinuousEnter{false}, _isJustAccepted{false}, _isNewLine{true};
-        std::atomic<types::Time> _currentRetrieveTime;
+        std::atomic<bool> _isAutoCompletion{true}, _isContinuousEnter{false}, _isJustAccepted{false},
+                _isNewLine{true}, _isRunning{true}, _needRetrieveCompletion{false};
+        std::atomic<types::Time> _debounceRetrieveCompletionTime, _wsActionSentTime;
         types::CompletionCache _completionCache;
 
-        void _cancelCompletion(bool isNeedReset = true);
+        void _cancelCompletion();
 
-        void _retrieveCompletion(const std::string& prefix);
+        void _sendCompletionGenerate();
 
-        void _retrieveEditorInfo() const;
-
-        void _updateComponents();
+        void _threadDebounceRetrieveCompletion();
     };
 }

--- a/components/CompletionManager.h
+++ b/components/CompletionManager.h
@@ -13,7 +13,7 @@ namespace components {
     class CompletionManager : public SingletonDclp<CompletionManager> {
     public:
         struct Components {
-            std::string cursorString;
+            types::CaretPosition caretPosition;
             std::string path;
             std::string prefix;
             std::string suffix;
@@ -28,18 +28,19 @@ namespace components {
 
         CompletionManager() = default;
 
-        std::optional<std::string> acceptCompletion(int line);
+        void interactionAcceptCompletion(const std::any&);
 
-        void cancelCompletion();
+        void interactionCaretUpdate(const std::any& data);
 
-        void deleteInput(const types::CaretPosition& position);
+        void interactionDeleteInput(const std::any&);
 
-        /**
-         * @brief Handles normal input and returns if need to trigger accept.
-         * @param character The character to be input.
-         * @return A boolean indicating whether the input was handled successfully.
-         */
-        bool normalInput(char character);
+        void interactionEnterInput(const std::any&);
+
+        void interactionNavigate(const std::any& data);
+
+        void interactionNormalInput(const std::any& data);
+
+        void interactionSave(const std::any&);
 
         void instantUndo(const std::any& = {});
 
@@ -63,7 +64,7 @@ namespace components {
         EditorInfo _editorInfo;
 
         // TODO: Check if _isJustAccepted is still needed
-        std::atomic<bool> _isAutoCompletion{true}, _isContinuousEnter{false}, _isJustAccepted{false};
+        std::atomic<bool> _isAutoCompletion{true}, _isContinuousEnter{false}, _isJustAccepted{false}, _isNewLine{true};
         std::atomic<types::Time> _currentRetrieveTime;
         types::CompletionCache _completionCache;
 
@@ -72,5 +73,7 @@ namespace components {
         void _retrieveCompletion(const std::string& prefix);
 
         void _retrieveEditorInfo() const;
+
+        void _updateComponents();
     };
 }

--- a/components/InteractionMonitor.h
+++ b/components/InteractionMonitor.h
@@ -23,9 +23,13 @@ namespace components {
 
         ~InteractionMonitor() override;
 
-        [[nodiscard]] std::tuple<int, int> getCaretPixels(int line) const;
+        [[nodiscard]] std::tuple<int64_t, int64_t> getCaretPixels(uint32_t line) const;
+
+        [[nodiscard]] types::CaretPosition getCaretPosition() const;
 
         [[nodiscard]] std::string getFileName() const;
+
+        [[nodiscard]] std::string getLineContent() const;
 
         [[nodiscard]] std::string getLineContent(uint32_t line) const;
 

--- a/components/InteractionMonitor.h
+++ b/components/InteractionMonitor.h
@@ -27,7 +27,7 @@ namespace components {
 
         [[nodiscard]] std::string getFileName() const;
 
-        [[nodiscard]] std::string getLineContent(int line) const;
+        [[nodiscard]] std::string getLineContent(uint32_t line) const;
 
         void setLineContent(uint32_t line, const std::string& content) const;
 

--- a/components/ModificationManager.cc
+++ b/components/ModificationManager.cc
@@ -1,28 +1,19 @@
+#include <components/InteractionMonitor.h>
 #include <components/ModificationManager.h>
-#include <utils/fs.h>
 #include <utils/logger.h>
-
-#include "InteractionMonitor.h"
 
 using namespace components;
 using namespace std;
 using namespace types;
 using namespace utils;
 
-CaretPosition ModificationManager::getCurrentPosition() {
-    try {
-        shared_lock lock(_currentModificationMutex);
-        return _currentFile().getPosition();
-    } catch (out_of_range&) {
-        return CaretPosition{};
-    }
-}
-
 void ModificationManager::interactionAcceptCompletion(const std::any&) {
     try {
         unique_lock lock(_currentModificationMutex);
         _currentFile().acceptCompletion();
-    } catch (out_of_range&) {}
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
+    }
 }
 
 void ModificationManager::interactionCaretUpdate(const any& data) {
@@ -32,15 +23,18 @@ void ModificationManager::interactionCaretUpdate(const any& data) {
         _currentFile().navigate(newCursorPosition);
     } catch (const bad_any_cast& e) {
         logger::log(format("Invalid interactionCaretUpdate data: {}", e.what()));
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
     }
-    catch (out_of_range&) {}
 }
 
 void ModificationManager::interactionDeleteInput(const any&) {
     try {
         unique_lock lock(_currentModificationMutex);
         _currentFile().remove();
-    } catch (out_of_range&) {}
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
+    }
 }
 
 void ModificationManager::interactionEnterInput(const any&) {
@@ -54,8 +48,9 @@ void ModificationManager::interactionNavigate(const any& data) {
         _currentFile().navigate(key);
     } catch (const bad_any_cast& e) {
         logger::log(format("Invalid interactionNavigate data: {}", e.what()));
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
     }
-    catch (out_of_range&) {}
 }
 
 void ModificationManager::interactionNormalInput(const any& data) {
@@ -65,8 +60,9 @@ void ModificationManager::interactionNormalInput(const any& data) {
         _currentFile().add(keycode);
     } catch (const bad_any_cast& e) {
         logger::log(format("Invalid interactionNormalInput data: {}", e.what()));
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
     }
-    catch (out_of_range&) {}
 }
 
 void ModificationManager::interactionSave(const std::any&) {
@@ -76,14 +72,18 @@ void ModificationManager::interactionSave(const std::any&) {
             unique_lock lock(_currentModificationMutex);
             _currentFile().reload();
         }).detach();
-    } catch (out_of_range&) {}
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
+    }
 }
 
 void ModificationManager::interactionSelectionClear(const std::any&) {
     try {
         unique_lock lock(_currentModificationMutex);
         _currentFile().selectionClear();
-    } catch (out_of_range&) {}
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
+    }
 }
 
 void ModificationManager::interactionSelectionSet(const std::any& data) {
@@ -93,8 +93,9 @@ void ModificationManager::interactionSelectionSet(const std::any& data) {
         _currentFile().selectionSet(range);
     } catch (const bad_any_cast& e) {
         logger::log(format("Invalid interactionSelectionSet data: {}", e.what()));
+    } catch (const runtime_error& e) {
+        logger::warn(e.what());
     }
-    catch (out_of_range&) {}
 }
 
 Modification& ModificationManager::_currentFile() {

--- a/components/ModificationManager.h
+++ b/components/ModificationManager.h
@@ -5,7 +5,6 @@
 #include <nlohmann/json.hpp>
 #include <singleton_dclp.hpp>
 
-#include <types/CaretPosition.h>
 #include <types/Modification.h>
 
 namespace components {
@@ -14,9 +13,6 @@ namespace components {
         ModificationManager() = default;
 
         ~ModificationManager() override = default;
-
-        // TODO: Remove temporary methods
-        types::CaretPosition getCurrentPosition();
 
         void interactionAcceptCompletion(const std::any&);
 

--- a/components/WebsocketManager.cc
+++ b/components/WebsocketManager.cc
@@ -15,11 +15,6 @@ WebsocketManager::WebsocketManager(string&& url, const chrono::seconds& pingInte
     initNetSystem();
     _client.setUrl(url);
     _client.setPingInterval(static_cast<int>(pingInterval.count()));
-    _client.setOnMessageCallback([](const WebSocketMessagePtr& msg) {
-        if (msg->type == WebSocketMessageType::Message) {
-            logger::debug(msg->str);
-        }
-    });
     _client.setOnMessageCallback([this](const WebSocketMessagePtr& messagePtr) {
         switch (messagePtr->type) {
             case WebSocketMessageType::Message: {

--- a/components/WindowManager.cc
+++ b/components/WindowManager.cc
@@ -87,7 +87,7 @@ void WindowManager::_threadDebounceRetrieveInfo() {
             if (_needRetrieveInfo.load()) {
                 if (const auto deltaTime = _debounceRetrieveInfoTime.load() - chrono::high_resolution_clock::now();
                     deltaTime <= chrono::nanoseconds(0)) {
-                    logger::log("Sending retrieve info...");
+                    logger::info("Retrieve info from Source Insight");
                     window::postKeycode(
                         _codeWindowHandle,
                         _keyHelper.toKeycode(Key::F11, {Modifier::Shift, Modifier::Ctrl, Modifier::Alt})

--- a/components/WindowManager.cc
+++ b/components/WindowManager.cc
@@ -40,11 +40,11 @@ bool WindowManager::checkNeedShowWhenGainFocus(const int64_t windowHandle) {
     return false;
 }
 
-std::tuple<int, int> WindowManager::getCurrentPosition() const {
+tuple<int64_t, int64_t> WindowManager::getCurrentPosition() const {
     return window::getClientPosition(_codeWindowHandle);
 }
 
-void WindowManager::interactionPaste(const std::any&) {
+void WindowManager::interactionPaste(const any&) {
     _cancelRetrieveInfo();
 }
 

--- a/components/WindowManager.cc
+++ b/components/WindowManager.cc
@@ -44,6 +44,10 @@ tuple<int64_t, int64_t> WindowManager::getCurrentPosition() const {
     return window::getClientPosition(_codeWindowHandle);
 }
 
+bool WindowManager::hasValidCodeWindow() const {
+    return _codeWindowHandle.load() > 0;
+}
+
 void WindowManager::interactionPaste(const any&) {
     _cancelRetrieveInfo();
 }

--- a/components/WindowManager.h
+++ b/components/WindowManager.h
@@ -17,7 +17,7 @@ namespace components {
 
         bool checkNeedShowWhenGainFocus(int64_t windowHandle);
 
-        std::tuple<int, int> getCurrentPosition() const;
+        std::tuple<int64_t, int64_t> getCurrentPosition() const;
 
         void interactionPaste(const std::any& = {});
 

--- a/components/WindowManager.h
+++ b/components/WindowManager.h
@@ -19,6 +19,8 @@ namespace components {
 
         std::tuple<int64_t, int64_t> getCurrentPosition() const;
 
+        bool hasValidCodeWindow() const;
+
         void interactionPaste(const std::any& = {});
 
         void requestRetrieveInfo();

--- a/main.cc
+++ b/main.cc
@@ -56,8 +56,18 @@ BOOL __stdcall DllMain(const HMODULE hModule, const DWORD dwReason, [[maybe_unus
 
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::AcceptCompletion,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionAcceptCompletion
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::AcceptCompletion,
                 ModificationManager::GetInstance(),
                 &ModificationManager::interactionAcceptCompletion
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::CaretUpdate,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionCaretUpdate
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::CaretUpdate,
@@ -66,8 +76,18 @@ BOOL __stdcall DllMain(const HMODULE hModule, const DWORD dwReason, [[maybe_unus
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::DeleteInput,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionDeleteInput
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::DeleteInput,
                 ModificationManager::GetInstance(),
                 &ModificationManager::interactionDeleteInput
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::EnterInput,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionEnterInput
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::EnterInput,
@@ -76,13 +96,28 @@ BOOL __stdcall DllMain(const HMODULE hModule, const DWORD dwReason, [[maybe_unus
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::Navigate,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionNavigate
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::Navigate,
                 ModificationManager::GetInstance(),
                 &ModificationManager::interactionNavigate
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::NormalInput,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionNormalInput
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::NormalInput,
                 ModificationManager::GetInstance(),
                 &ModificationManager::interactionNormalInput
+            );
+            InteractionMonitor::GetInstance()->registerInteraction(
+                Interaction::Save,
+                CompletionManager::GetInstance(),
+                &CompletionManager::interactionSave
             );
             InteractionMonitor::GetInstance()->registerInteraction(
                 Interaction::Save,

--- a/types/Modification.cc
+++ b/types/Modification.cc
@@ -8,8 +8,8 @@
 #include <regex>
 #include <utility>
 #include <algorithm>
-#include <components/CompletionManager.h>
 
+#include <components/CompletionManager.h>
 #include <components/WebsocketManager.h>
 #include <helpers/HttpHelper.h>
 #include <types/IndentType.h>
@@ -40,17 +40,18 @@ Modification::Modification(string path): path(move(path)) {
 }
 
 void Modification::acceptCompletion() {
-    if (const auto completionOpt = CompletionManager::GetInstance()->acceptCompletion(_lastPosition.line);
-        completionOpt.has_value()) {
-        add(completionOpt.value());
+    // if (const auto completionOpt = CompletionManager::GetInstance()->acceptCompletion(_lastPosition.line);
+    //     completionOpt.has_value()) {
+    //     add(completionOpt.value());
+    // } else {
+    // TODO: Implement acceptCompletion
+    if (!_lastSelect.isEmpty()) {
+        const auto selectContent = _addRangeIndent(_lastSelect);
+        _setRangeContent(_lastSelect, selectContent);
     } else {
-        if (!_lastSelect.isEmpty()) {
-            const auto selectContent = _addRangeIndent(_lastSelect);
-            _setRangeContent(_lastSelect, selectContent);
-        } else {
-            add(tabString);
-        }
+        add(tabString);
     }
+    // }
 }
 
 /**
@@ -129,9 +130,6 @@ void Modification::add(const char character) {
             offset += 1;
         }
     }
-    if (CompletionManager::GetInstance()->normalInput(character)) {
-        CompletionManager::GetInstance()->acceptCompletion(_lastPosition.line);
-    }
     _debugSync();
 }
 
@@ -175,7 +173,6 @@ void Modification::navigate(const CaretPosition& newPosition) {
         newPosition.line < _lineOffsets.size() &&
         newPosition.character <= _getLineLength(newPosition.line)) {
         _lastPosition = newPosition;
-        CompletionManager::GetInstance()->cancelCompletion();
     }
 }
 
@@ -184,7 +181,6 @@ void Modification::navigate(const CaretPosition& newPosition) {
  * @param key The key that determines how to navigate.
  */
 void Modification::navigate(const Key key) {
-    CompletionManager::GetInstance()->cancelCompletion();
     switch (key) {
         // TODO: Implement these keys
         // case Key::Home: {
@@ -263,7 +259,6 @@ void Modification::reload() {
         _lineOffsets.push_back(_lineOffsets.back() + line.size() + 1);
     }
     _lineOffsets.pop_back();
-    CompletionManager::GetInstance()->cancelCompletion();
     _debugSync();
 }
 
@@ -271,7 +266,6 @@ void Modification::reload() {
  * @brief Removes a character from the content at the current position.
  */
 void Modification::remove() {
-    CompletionManager::GetInstance()->deleteInput(_lastPosition);
     if (!_lastSelect.isEmpty()) {
         logger::info(format(
             "Remove selection from ({}, {}) to ({}, {})",
@@ -304,12 +298,10 @@ void Modification::remove() {
 }
 
 void Modification::selectionClear() {
-    // TODO: Check if need call CompletionManager
     _lastSelect.reset();
 }
 
 void Modification::selectionSet(const Range& range) {
-    // TODO: Check if need call CompletionManager
     _lastSelect = range;
 }
 

--- a/types/Modification.cc
+++ b/types/Modification.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <algorithm>
 
-#include <components/CompletionManager.h>
 #include <components/WebsocketManager.h>
 #include <helpers/HttpHelper.h>
 #include <types/IndentType.h>

--- a/utils/memory.cc
+++ b/utils/memory.cc
@@ -18,7 +18,7 @@ namespace {
                     SiVersion::Minor::V0086, {
                         {
                             {
-                                {0x1C4C10, 0x000024},
+                                {0x1CCD44, 0x000024},
                                 {
                                     0x1CCD44,
                                     {0x1007D7},

--- a/utils/window.cc
+++ b/utils/window.cc
@@ -15,14 +15,14 @@ string window::getWindowClassName(const int64_t hwnd) {
     return text.substr(0, GetClassName(reinterpret_cast<HWND>(hwnd), text.data(), 256));
 }
 
-tuple<int, int> window::getClientPosition(const int64_t hwnd) {
+tuple<int64_t, int64_t> window::getClientPosition(const int64_t hwnd) {
     POINT ptClient = {};
     ClientToScreen(reinterpret_cast<HWND>(hwnd), &ptClient);
 
     return {ptClient.x, ptClient.y};
 }
 
-tuple<int, int> window::getWindowPosition(const int64_t hwnd) {
+tuple<int64_t, int64_t> window::getWindowPosition(const int64_t hwnd) {
     RECT rect;
     GetWindowRect(reinterpret_cast<HWND>(hwnd), &rect);
     return {rect.left, rect.top};

--- a/utils/window.h
+++ b/utils/window.h
@@ -7,9 +7,9 @@
 namespace utils::window {
     std::string getWindowClassName(int64_t hwnd);
 
-    std::tuple<int, int> getClientPosition(int64_t hwnd);
+    std::tuple<int64_t, int64_t> getClientPosition(int64_t hwnd);
 
-    std::tuple<int, int> getWindowPosition(int64_t hwnd);
+    std::tuple<int64_t, int64_t> getWindowPosition(int64_t hwnd);
 
     std::string getWindowText(int64_t hwnd);
 


### PR DESCRIPTION
- Fix fatal callback when window & file handle is not available
- Detect keyword when inputting ';' in CompletionManager
- Remove redundant setOnMessageCallback in WebsocketManager
- Add hasValidCodeWindow to WindowManager
- Remove unnecessary shared_lock in CompletionManager